### PR TITLE
Change tooltip position

### DIFF
--- a/src/NucleotideTooltip.js
+++ b/src/NucleotideTooltip.js
@@ -14,8 +14,8 @@ export default class NucleotideTooltip extends React.Component {
     render() {
         return <MouseTooltip
             visible={true}
-            offsetX={-15}
-            offsetY={-10}
+            offsetX={15}
+            offsetY={-20}
             style={{'background':'white'}}>
                 <Observer>{() => <span>{this.props.store.cellToolTipContent}</span>}</Observer>
         </MouseTooltip>;

--- a/src/NucleotideTooltip.js
+++ b/src/NucleotideTooltip.js
@@ -14,8 +14,8 @@ export default class NucleotideTooltip extends React.Component {
     render() {
         return <MouseTooltip
             visible={true}
-            offsetX={15}
-            offsetY={10}
+            offsetX={-15}
+            offsetY={-10}
             style={{'background':'white'}}>
                 <Observer>{() => <span>{this.props.store.cellToolTipContent}</span>}</Observer>
         </MouseTooltip>;


### PR DESCRIPTION
We have padding on top, but we don't have any padding on bottom. So, it is better to show the tooltip on the upper right.

If we move a cursor to the right end, we can't see the tooltip. That's still issue. We need to adjust the position of tooltip depending on the position of cursor.