### PR TITLE
fix: parse int so mobx actually sets topOffSet

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -96,7 +96,7 @@ class App extends Component {
             calculateLinkCoordinates(this.schematic.components, this.props.store.pixelsPerColumn, this.props.store.topOffset,
                 this.leftXStart.bind(this));
         this.distanceSortedLinks = links;
-        this.props.store.updateTopOffset(top);
+        this.props.store.updateTopOffset(parseInt(top));
     }
 
     recalcY(){


### PR DESCRIPTION
I think this is what the ticket wants? The updateTopOffset wasn't actually updating the topoffset because decimals