### PR TITLE
Reduce error messages due to type annotation

### DIFF
--- a/src/ComponentConnectorRect.js
+++ b/src/ComponentConnectorRect.js
@@ -59,7 +59,7 @@ export class MatrixCell extends React.Component {
 }
 
 MatrixCell.propTypes = {
-  store: PropTypes.node,
+  store: PropTypes.object,
   item: PropTypes.node,
   x: PropTypes.number,
   y: PropTypes.number,

--- a/src/ComponentRect.js
+++ b/src/ComponentRect.js
@@ -177,9 +177,9 @@ class ComponentRect extends React.Component {
 }
 
 ComponentRect.propTypes = {
-  store: PropTypes.node,
-  item: PropTypes.node,
-  compressed_row_mapping: PropTypes.node,
+  store: PropTypes.object,
+  item: PropTypes.object,
+  compressed_row_mapping: PropTypes.object,
   width: PropTypes.node,
   height: PropTypes.node,
   pathNames: PropTypes.node,

--- a/src/ControlHeader.js
+++ b/src/ControlHeader.js
@@ -181,7 +181,7 @@ class ControlHeader extends React.Component {
 }
 
 ControlHeader.propTypes = {
-  store: PropTypes.node,
+  store: PropTypes.object,
 };
 
 class CompressedViewSwitch extends React.Component {
@@ -199,6 +199,6 @@ class CompressedViewSwitch extends React.Component {
 }
 
 CompressedViewSwitch.propTypes = {
-  store: PropTypes.node,
+  store: PropTypes.object,
 };
 export default ControlHeader;

--- a/src/LinkArrow.js
+++ b/src/LinkArrow.js
@@ -135,10 +135,10 @@ class LinkArrow extends React.Component {
 }
 
 LinkArrow.propTypes = {
-  store: PropTypes.node,
-  link: PropTypes.node,
+  store: PropTypes.object,
+  link: PropTypes.object,
   color: PropTypes.node,
-  updateHighlightedNode: PropTypes.node,
+  updateHighlightedNode: PropTypes.func,
 };
 
 export default LinkArrow;

--- a/src/LinkColumn.js
+++ b/src/LinkColumn.js
@@ -62,10 +62,10 @@ class LinkColumn extends React.Component {
 }
 
 LinkColumn.propTypes = {
-  store: PropTypes.node,
-  item: PropTypes.node,
-  updateHighlightedNode: PropTypes.node,
-  compressed_row_mapping: PropTypes.node,
+  store: PropTypes.object,
+  item: PropTypes.object,
+  updateHighlightedNode: PropTypes.func,
+  compressed_row_mapping: PropTypes.object,
   x: PropTypes.node,
   column: PropTypes.node,
   color: PropTypes.node,

--- a/src/NucleotideTooltip.js
+++ b/src/NucleotideTooltip.js
@@ -21,5 +21,5 @@ export default class NucleotideTooltip extends React.Component {
 }
 
 NucleotideTooltip.propTypes = {
-  store: PropTypes.node,
+  store: PropTypes.object,
 };

--- a/src/ViewportInputsStore.js
+++ b/src/ViewportInputsStore.js
@@ -19,7 +19,7 @@ RootStore = types
     highlightedLink: 0, // we will compare linkColumns
     maximumHeightThisFrame: 150,
     cellToolTipContent: "",
-    jsonName: "run1.B1phi1.i1.seqwish.w100",
+    jsonName: "nonconsecutive_chunks",
     startChunkURL: "",
     endChunkURL: "",
     pathNucPos: types.optional(PathNucPos, { path: "path", nucPos: 0 }), // OR: types.maybe(PathNucPos)

--- a/src/ViewportInputsStore.js
+++ b/src/ViewportInputsStore.js
@@ -19,7 +19,7 @@ RootStore = types
     highlightedLink: 0, // we will compare linkColumns
     maximumHeightThisFrame: 150,
     cellToolTipContent: "",
-    jsonName: "nonconsecutive_chunks",
+    jsonName: "run1.B1phi1.i1.seqwish.w100",
     startChunkURL: "",
     endChunkURL: "",
     pathNucPos: types.optional(PathNucPos, { path: "path", nucPos: 0 }), // OR: types.maybe(PathNucPos)


### PR DESCRIPTION
There is incompatibility between propTypes and actual props.
<img width="517" alt="2020-04-08 13 44 03" src="https://user-images.githubusercontent.com/12047794/78745528-5c171900-799f-11ea-8b9c-100216f626a2.png">
