### PR TITLE
Add toggleRenderMatrix option to hide SNPs in the Matrix

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -332,7 +332,7 @@ class App extends Component {
   };
 
   render() {
-    console.log("Start render");
+    console.log("Start render", this.props.store);
     return (
       <>
         <ControlHeader store={this.props.store} />

--- a/src/App.js
+++ b/src/App.js
@@ -71,6 +71,11 @@ class App extends Component {
       this.recalcXLayout.bind(this)
     );
     observe(this.props.store, "useConnector", this.recalcXLayout.bind(this));
+    observe(
+      this.props.store,
+      "binScalingFactor",
+      this.recalcXLayout.bind(this)
+    );
     observe(this.props.store, "pixelsPerColumn", this.recalcXLayout.bind(this));
     observe(this.props.store.chunkURLs, this.nextChunk.bind(this));
     // this.nextChunk();
@@ -128,7 +133,7 @@ class App extends Component {
           component.arrivals.length +
           (component.departures.length - 1) +
           (this.props.store.useWidthCompression
-            ? 1
+            ? this.props.store.binScalingFactor
             : component.lastBin - component.firstBin) +
           1
       )
@@ -146,6 +151,7 @@ class App extends Component {
       this.props.store.pixelsPerColumn,
       this.props.store.topOffset,
       this.props.store.useWidthCompression,
+      this.props.store.binScalingFactor,
       this.leftXStart.bind(this)
     );
     this.distanceSortedLinks = links;
@@ -230,7 +236,8 @@ class App extends Component {
       ? schematizeComponent.firstBin -
         this.props.store.getBeginBin() +
         schematizeComponent.offset
-      : schematizeComponent.offset + schematizeComponent.index;
+      : schematizeComponent.offset +
+        schematizeComponent.index * this.props.store.binScalingFactor;
     let pixelsFromColumns =
       (previousColumns + firstDepartureColumn + j) *
       this.props.store.pixelsPerColumn;
@@ -248,7 +255,7 @@ class App extends Component {
           width={
             schematizeComponent.arrivals.length +
             (this.props.store.useWidthCompression
-              ? 1
+              ? this.props.store.binScalingFactor
               : schematizeComponent.num_bin) +
             (schematizeComponent.departures.length - 1)
           }
@@ -267,9 +274,9 @@ class App extends Component {
         })}
         {schematizeComponent.departures.slice(0, -1).map((linkColumn, j) => {
           let leftPad =
-            schematizeComponent.arrivals +
+            schematizeComponent.arrivals.length +
             (this.props.store.useWidthCompression
-              ? 1
+              ? this.props.store.binScalingFactor
               : schematizeComponent.num_bin);
           return this.renderLinkColumn(
             schematizeComponent,

--- a/src/App.js
+++ b/src/App.js
@@ -70,6 +70,7 @@ class App extends Component {
       "useWidthCompression",
       this.recalcXLayout.bind(this)
     );
+    observe(this.props.store, "useConnector", this.recalcXLayout.bind(this));
     observe(this.props.store, "pixelsPerColumn", this.recalcXLayout.bind(this));
     observe(this.props.store.chunkURLs, this.nextChunk.bind(this));
     // this.nextChunk();

--- a/src/App.js
+++ b/src/App.js
@@ -70,7 +70,6 @@ class App extends Component {
       "useWidthCompression",
       this.recalcXLayout.bind(this)
     );
-    observe(this.props.store, "useConnector", this.recalcXLayout.bind(this));
     observe(this.props.store, "pixelsPerColumn", this.recalcXLayout.bind(this));
     observe(this.props.store.chunkURLs, this.nextChunk.bind(this));
     // this.nextChunk();

--- a/src/App.js
+++ b/src/App.js
@@ -237,7 +237,8 @@ class App extends Component {
         this.props.store.getBeginBin() +
         schematizeComponent.offset
       : schematizeComponent.offset +
-        schematizeComponent.index * this.props.store.binScalingFactor;
+        (schematizeComponent.index - this.schematic.components[0].index) *
+          this.props.store.binScalingFactor;
     let pixelsFromColumns =
       (previousColumns + firstDepartureColumn + j) *
       this.props.store.pixelsPerColumn;

--- a/src/App.js
+++ b/src/App.js
@@ -41,7 +41,6 @@ const stringToColourSave = function (colorKey) {
 };
 
 class App extends Component {
-
   layerRef = React.createRef();
   layerRef2 = React.createRef(null);
   constructor(props) {
@@ -71,6 +70,7 @@ class App extends Component {
       "useWidthCompression",
       this.recalcXLayout.bind(this)
     );
+    observe(this.props.store, "useConnector", this.recalcXLayout.bind(this));
     observe(this.props.store, "pixelsPerColumn", this.recalcXLayout.bind(this));
     observe(this.props.store.chunkURLs, this.nextChunk.bind(this));
     // this.nextChunk();
@@ -127,7 +127,9 @@ class App extends Component {
         (component) =>
           component.arrivals.length +
           (component.departures.length - 1) +
-          (this.props.store.useWidthCompression ? 1 : (component.lastBin - component.firstBin)) +
+          (this.props.store.useWidthCompression
+            ? 1
+            : component.lastBin - component.firstBin) +
           1
       )
       .reduce(sum, 0);
@@ -224,10 +226,11 @@ class App extends Component {
 
   leftXStart(schematizeComponent, i, firstDepartureColumn, j) {
     /* Return the x coordinate pixel that starts the LinkColumn at i, j*/
-    let previousColumns = !this.props.store.useWidthCompression ? 
-      (schematizeComponent.firstBin -
-      this.props.store.getBeginBin() +
-      schematizeComponent.offset) : (schematizeComponent.offset + schematizeComponent.index);
+    let previousColumns = !this.props.store.useWidthCompression
+      ? schematizeComponent.firstBin -
+        this.props.store.getBeginBin() +
+        schematizeComponent.offset
+      : schematizeComponent.offset + schematizeComponent.index;
     let pixelsFromColumns =
       (previousColumns + firstDepartureColumn + j) *
       this.props.store.pixelsPerColumn;
@@ -244,7 +247,9 @@ class App extends Component {
           height={this.visibleHeight()}
           width={
             schematizeComponent.arrivals.length +
-            (this.props.store.useWidthCompression ? 1 : schematizeComponent.num_bin) +
+            (this.props.store.useWidthCompression
+              ? 1
+              : schematizeComponent.num_bin) +
             (schematizeComponent.departures.length - 1)
           }
           compressed_row_mapping={this.compressed_row_mapping}
@@ -261,7 +266,11 @@ class App extends Component {
           );
         })}
         {schematizeComponent.departures.slice(0, -1).map((linkColumn, j) => {
-          let leftPad = schematizeComponent.arrivals + (this.props.store.useWidthCompression ? 1 : schematizeComponent.num_bin);
+          let leftPad =
+            schematizeComponent.arrivals +
+            (this.props.store.useWidthCompression
+              ? 1
+              : schematizeComponent.num_bin);
           return this.renderLinkColumn(
             schematizeComponent,
             i,

--- a/src/App.js
+++ b/src/App.js
@@ -332,7 +332,7 @@ class App extends Component {
   };
 
   render() {
-    console.log("Start render", this.props.store);
+    console.log("Start render");
     return (
       <>
         <ControlHeader store={this.props.store} />

--- a/src/ComponentRect.js
+++ b/src/ComponentRect.js
@@ -140,7 +140,9 @@ class ComponentRect extends React.Component {
     // x is the (num_bins + num_arrivals + num_departures)*pixelsPerColumn
     const x_val =
       component.x +
-      (component.firstDepartureColumn() + component.departures.length - 1) *
+      (component.arrivals.length +
+        (this.props.store.useWidthCompression ? 1 : component.num_bin)
+         + component.departures.length - 1) *
         this.props.store.pixelsPerColumn;
     let this_y = count;
     if (!this.props.store.useVerticalCompression) {
@@ -169,8 +171,8 @@ class ComponentRect extends React.Component {
           fill={this.state.color}
           onClick={this.handleClick}
         ></Rect>
-        {this.props.store.useRenderMatrix ? this.renderMatrix() : null}
-        {this.renderAllConnectors()}
+        {!this.props.store.useWidthCompression ? this.renderMatrix() : null}
+        {this.props.store.useConnector ? this.renderAllConnectors() : null}
       </>
     );
   }

--- a/src/ComponentRect.js
+++ b/src/ComponentRect.js
@@ -169,7 +169,7 @@ class ComponentRect extends React.Component {
           fill={this.state.color}
           onClick={this.handleClick}
         ></Rect>
-        {this.renderMatrix()}
+        {this.props.store.useRenderMatrix ? this.renderMatrix() : null}
         {this.renderAllConnectors()}
       </>
     );

--- a/src/ComponentRect.js
+++ b/src/ComponentRect.js
@@ -141,7 +141,9 @@ class ComponentRect extends React.Component {
     const x_val =
       component.x +
       (component.arrivals.length +
-        (this.props.store.useWidthCompression ? 1 : component.num_bin) +
+        (this.props.store.useWidthCompression
+          ? this.props.store.binScalingFactor
+          : component.num_bin) +
         component.departures.length -
         1) *
         this.props.store.pixelsPerColumn;
@@ -173,9 +175,7 @@ class ComponentRect extends React.Component {
           onClick={this.handleClick}
         ></Rect>
         {!this.props.store.useWidthCompression ? this.renderMatrix() : null}
-        {!this.props.store.useWidthCompression
-          ? this.renderAllConnectors()
-          : null}
+        {this.props.store.useConnector ? this.renderAllConnectors() : null}
       </>
     );
   }

--- a/src/ComponentRect.js
+++ b/src/ComponentRect.js
@@ -173,7 +173,9 @@ class ComponentRect extends React.Component {
           onClick={this.handleClick}
         ></Rect>
         {!this.props.store.useWidthCompression ? this.renderMatrix() : null}
-        {this.renderAllConnectors()}
+        {!this.props.store.useWidthCompression
+          ? this.renderAllConnectors()
+          : null}
       </>
     );
   }

--- a/src/ComponentRect.js
+++ b/src/ComponentRect.js
@@ -173,9 +173,7 @@ class ComponentRect extends React.Component {
           onClick={this.handleClick}
         ></Rect>
         {!this.props.store.useWidthCompression ? this.renderMatrix() : null}
-        {!this.props.store.useWidthCompression
-          ? this.renderAllConnectors()
-          : null}
+        {this.renderAllConnectors()}
       </>
     );
   }

--- a/src/ComponentRect.js
+++ b/src/ComponentRect.js
@@ -141,8 +141,9 @@ class ComponentRect extends React.Component {
     const x_val =
       component.x +
       (component.arrivals.length +
-        (this.props.store.useWidthCompression ? 1 : component.num_bin)
-         + component.departures.length - 1) *
+        (this.props.store.useWidthCompression ? 1 : component.num_bin) +
+        component.departures.length -
+        1) *
         this.props.store.pixelsPerColumn;
     let this_y = count;
     if (!this.props.store.useVerticalCompression) {
@@ -172,7 +173,9 @@ class ComponentRect extends React.Component {
           onClick={this.handleClick}
         ></Rect>
         {!this.props.store.useWidthCompression ? this.renderMatrix() : null}
-        {this.props.store.useConnector ? this.renderAllConnectors() : null}
+        {!this.props.store.useWidthCompression
+          ? this.renderAllConnectors()
+          : null}
       </>
     );
   }

--- a/src/ControlHeader.js
+++ b/src/ControlHeader.js
@@ -163,11 +163,32 @@ class ControlHeader extends React.Component {
             Use Width Compression:
             <WidthCompressedViewSwitch store={this.props.store} />
           </span>
-          <span>
-            {" "}
-            Render Connectors:
-            <RenderConnectorSwitch store={this.props.store} />
-          </span>
+          {this.props.store.useWidthCompression ? (
+            <React.Fragment>
+              <span>
+                {" "}
+                Render Connectors:
+                <RenderConnectorSwitch store={this.props.store} />
+              </span>
+              <span>
+                {" "}
+                Component Width Scaling Factor:
+                <Observer>
+                  {() => (
+                    <input
+                      type="number"
+                      min={1}
+                      value={this.props.store.binScalingFactor}
+                      onChange={this.props.store.updateBinScalingFactor}
+                      style={{ width: "30px" }}
+                    />
+                  )}
+                </Observer>
+              </span>
+            </React.Fragment>
+          ) : (
+            <></>
+          )}
           <span>
             {" "}
             Row Height:

--- a/src/ControlHeader.js
+++ b/src/ControlHeader.js
@@ -156,12 +156,17 @@ class ControlHeader extends React.Component {
           <span>
             {" "}
             Use Vertical Compression:
-            <CompressedViewSwitch store={this.props.store} />
+            <VerticalCompressedViewSwitch store={this.props.store} />
           </span>
           <span>
             {" "}
-            Use Render Matrix:
-            <RenderMatrixSwitch store={this.props.store} />
+            Use Width Compression:
+            <WidthCompressedViewSwitch store={this.props.store} />
+          </span>
+          <span>
+            {" "}
+            Render Connectors:
+            <RenderConnectorSwitch store={this.props.store} />
           </span>
           <span>
             {" "}
@@ -195,7 +200,7 @@ ControlHeader.propTypes = {
   store: PropTypes.object,
 };
 
-class CompressedViewSwitch extends React.Component {
+class VerticalCompressedViewSwitch extends React.Component {
   render() {
     return (
       <Observer>
@@ -211,7 +216,7 @@ class CompressedViewSwitch extends React.Component {
   }
 }
 
-CompressedViewSwitch.propTypes = {
+VerticalCompressedViewSwitch.propTypes = {
   store: PropTypes.object,
 };
 
@@ -234,5 +239,46 @@ class RenderMatrixSwitch extends React.Component {
 RenderMatrixSwitch.propTypes = {
   store: PropTypes.object,
 };
+
+class RenderConnectorSwitch extends React.Component {
+  render() {
+    return (
+      <Observer>
+        {() => (
+          <input
+            type="checkbox"
+            checked={this.props.store.useConnector}
+            onChange={this.props.store.toggleUseConnector}
+          />
+        )}
+      </Observer>
+    );
+  }
+}
+
+RenderConnectorSwitch.propTypes = {
+  store: PropTypes.object,
+};
+
+class WidthCompressedViewSwitch extends React.Component {
+  render() {
+    return (
+      <Observer>
+        {() => (
+          <input
+            type="checkbox"
+            checked={this.props.store.useWidthCompression}
+            onChange={this.props.store.toggleUseWidthCompression}
+          />
+        )}
+      </Observer>
+    );
+  }
+}
+
+WidthCompressedViewSwitch.propTypes = {
+  store: PropTypes.object,
+};
+
 
 export default ControlHeader;

--- a/src/ControlHeader.js
+++ b/src/ControlHeader.js
@@ -220,26 +220,6 @@ VerticalCompressedViewSwitch.propTypes = {
   store: PropTypes.object,
 };
 
-class RenderMatrixSwitch extends React.Component {
-  render() {
-    return (
-      <Observer>
-        {() => (
-          <input
-            type="checkbox"
-            checked={this.props.store.useRenderMatrix}
-            onChange={this.props.store.toggleUseRenderMatrix}
-          />
-        )}
-      </Observer>
-    );
-  }
-}
-
-RenderMatrixSwitch.propTypes = {
-  store: PropTypes.object,
-};
-
 class RenderConnectorSwitch extends React.Component {
   render() {
     return (
@@ -279,6 +259,5 @@ class WidthCompressedViewSwitch extends React.Component {
 WidthCompressedViewSwitch.propTypes = {
   store: PropTypes.object,
 };
-
 
 export default ControlHeader;

--- a/src/ControlHeader.js
+++ b/src/ControlHeader.js
@@ -154,6 +154,11 @@ class ControlHeader extends React.Component {
           </span>
           <span>
             {" "}
+            Use Render Matrix:
+            <RenderMatrixSwitch store={this.props.store} />
+          </span>
+          <span>
+            {" "}
             Row Height:
             <input
               type="number"
@@ -187,13 +192,15 @@ ControlHeader.propTypes = {
 class CompressedViewSwitch extends React.Component {
   render() {
     return (
-      <input
-        type="checkbox"
-        value={
-          <Observer>{() => this.props.store.useVerticalCompression}</Observer>
-        }
-        onChange={this.props.store.toggleUseVerticalCompression}
-      />
+      <Observer>
+        {() => (
+          <input
+            type="checkbox"
+            checked={this.props.store.useVerticalCompression}
+            onChange={this.props.store.toggleUseVerticalCompression}
+          />
+        )}
+      </Observer>
     );
   }
 }
@@ -201,4 +208,25 @@ class CompressedViewSwitch extends React.Component {
 CompressedViewSwitch.propTypes = {
   store: PropTypes.node,
 };
+
+class RenderMatrixSwitch extends React.Component {
+  render() {
+    return (
+      <Observer>
+        {() => (
+          <input
+            type="checkbox"
+            checked={this.props.store.useRenderMatrix}
+            onChange={this.props.store.toggleUseRenderMatrix}
+          />
+        )}
+      </Observer>
+    );
+  }
+}
+
+RenderMatrixSwitch.propTypes = {
+  store: PropTypes.object,
+};
+
 export default ControlHeader;

--- a/src/ControlHeader.js
+++ b/src/ControlHeader.js
@@ -165,6 +165,11 @@ class ControlHeader extends React.Component {
           </span>
           <span>
             {" "}
+            Render Connectors:
+            <RenderConnectorSwitch store={this.props.store} />
+          </span>
+          <span>
+            {" "}
             Row Height:
             <input
               type="number"
@@ -212,6 +217,26 @@ class VerticalCompressedViewSwitch extends React.Component {
 }
 
 VerticalCompressedViewSwitch.propTypes = {
+  store: PropTypes.object,
+};
+
+class RenderConnectorSwitch extends React.Component {
+  render() {
+    return (
+      <Observer>
+        {() => (
+          <input
+            type="checkbox"
+            checked={this.props.store.useConnector}
+            onChange={this.props.store.toggleUseConnector}
+          />
+        )}
+      </Observer>
+    );
+  }
+}
+
+RenderConnectorSwitch.propTypes = {
   store: PropTypes.object,
 };
 

--- a/src/ControlHeader.js
+++ b/src/ControlHeader.js
@@ -165,11 +165,6 @@ class ControlHeader extends React.Component {
           </span>
           <span>
             {" "}
-            Render Connectors:
-            <RenderConnectorSwitch store={this.props.store} />
-          </span>
-          <span>
-            {" "}
             Row Height:
             <input
               type="number"
@@ -217,26 +212,6 @@ class VerticalCompressedViewSwitch extends React.Component {
 }
 
 VerticalCompressedViewSwitch.propTypes = {
-  store: PropTypes.object,
-};
-
-class RenderConnectorSwitch extends React.Component {
-  render() {
-    return (
-      <Observer>
-        {() => (
-          <input
-            type="checkbox"
-            checked={this.props.store.useConnector}
-            onChange={this.props.store.toggleUseConnector}
-          />
-        )}
-      </Observer>
-    );
-  }
-}
-
-RenderConnectorSwitch.propTypes = {
   store: PropTypes.object,
 };
 

--- a/src/LinkRecord.js
+++ b/src/LinkRecord.js
@@ -19,7 +19,8 @@ export function calculateLinkCoordinates(
   pixelsPerColumn,
   topOffset,
   useWidthCompression,
-  leftXStart,
+  binScalingFactor,
+  leftXStart
 ) {
   //leftXStart is necessary as a method at the moment
   /** calculate the x coordinates of all components
@@ -58,7 +59,10 @@ export function calculateLinkCoordinates(
       let xCoordDeparture = leftXStart(
         schematizeComponent,
         i,
-        schematizeComponent.arrivals.length + (useWidthCompression ? 1 : schematizeComponent.num_bin),
+        schematizeComponent.arrivals.length +
+          (useWidthCompression
+            ? binScalingFactor
+            : schematizeComponent.num_bin),
         k
       );
       let paddedKey = departure.key;

--- a/src/LinkRecord.js
+++ b/src/LinkRecord.js
@@ -18,7 +18,8 @@ export function calculateLinkCoordinates(
   schematic,
   pixelsPerColumn,
   topOffset,
-  leftXStart
+  useWidthCompression,
+  leftXStart,
 ) {
   //leftXStart is necessary as a method at the moment
   /** calculate the x coordinates of all components
@@ -57,7 +58,7 @@ export function calculateLinkCoordinates(
       let xCoordDeparture = leftXStart(
         schematizeComponent,
         i,
-        schematizeComponent.firstDepartureColumn(),
+        schematizeComponent.arrivals.length + (useWidthCompression ? 1 : schematizeComponent.num_bin),
         k
       );
       let paddedKey = departure.key;

--- a/src/PangenomeSchematic.js
+++ b/src/PangenomeSchematic.js
@@ -146,9 +146,9 @@ class PangenomeSchematic extends React.Component {
     } else {
       var componentArray = [];
       var offsetLength = 0;
-      for (var component of this.jsonData.components) {
+      for (let [index, component] of this.jsonData.components.entries()) {
         if (component.last_bin >= beginBin) {
-          var componentItem = new Component(component, offsetLength);
+          var componentItem = new Component(component, offsetLength, index);
           offsetLength +=
             componentItem.arrivals.length + componentItem.departures.length - 1;
           componentArray.push(componentItem);
@@ -169,8 +169,9 @@ class PangenomeSchematic extends React.Component {
 }
 
 class Component {
-  constructor(component, offsetLength) {
+  constructor(component, offsetLength, index) {
     this.offset = offsetLength;
+    this.index = index;
     this.firstBin = component.first_bin;
     this.lastBin = component.last_bin;
     this.arrivals = [];

--- a/src/PangenomeSchematic.js
+++ b/src/PangenomeSchematic.js
@@ -69,10 +69,10 @@ class PangenomeSchematic extends React.Component {
     return fetch(indexPath)
       .then((res) => res.json())
       .then((json) => {
-				if (!this.props.store.getChunkURLs()[0]) {
+        if (!this.props.store.getChunkURLs()[0]) {
           // Initial state
           this.props.store.switchChunkURLs(
-						`${process.env.PUBLIC_URL}test_data/${this.props.store.jsonName}/${json["files"][0]["file"]}`,
+            `${process.env.PUBLIC_URL}test_data/${this.props.store.jsonName}/${json["files"][0]["file"]}`,
             `${process.env.PUBLIC_URL}test_data/${this.props.store.jsonName}/${json["files"][1]["file"]}`
           );
         }
@@ -94,7 +94,10 @@ class PangenomeSchematic extends React.Component {
     this.pathNames = this.jsonData.path_names;
     this.jsonData.mid_bin = data.last_bin; //placeholder
     let lastChunkURLIndex = this.props.store.chunkURLs.length - 1;
-    if (this.props.store.getChunkURLs()[0] === this.props.store.getChunkURLs()[lastChunkURLIndex]) {
+    if (
+      this.props.store.getChunkURLs()[0] ===
+      this.props.store.getChunkURLs()[lastChunkURLIndex]
+    ) {
       this.processArray();
     } else {
       this.jsonFetch(this.props.store.getChunkURLs()[lastChunkURLIndex]).then(
@@ -189,9 +192,6 @@ class Component {
     this.occupants = Array.from(component.occupants);
     this.matrix = Array.from(component.matrix);
     this.num_bin = this.lastBin - this.firstBin + 1;
-  }
-  firstDepartureColumn() {
-    return this.num_bin + this.arrivals.length;
   }
 }
 

--- a/src/ViewportInputsStore.js
+++ b/src/ViewportInputsStore.js
@@ -11,6 +11,7 @@ export let RootStore;
 RootStore = types
   .model({
     useVerticalCompression: false,
+    useRenderMatrix: true,
     beginEndBin: BeginEndBin,
     pixelsPerColumn: 7,
     pixelsPerRow: 7,
@@ -70,6 +71,9 @@ RootStore = types
     }
     function toggleUseVerticalCompression() {
       self.useVerticalCompression = !self.useVerticalCompression;
+    }
+    function toggleUseRenderMatrix() {
+      self.useRenderMatrix = !self.useRenderMatrix;
     }
     function updateHeight(event) {
       self.pixelsPerRow = Math.max(1, Number(event.target.value));
@@ -131,6 +135,7 @@ RootStore = types
       resetRenderStats,
       updateCellTooltipContent,
       toggleUseVerticalCompression,
+      toggleUseRenderMatrix,
       updateHeight,
       updateWidth,
       tryJSONpath,

--- a/src/ViewportInputsStore.js
+++ b/src/ViewportInputsStore.js
@@ -15,6 +15,8 @@ RootStore = types
   .model({
     useVerticalCompression: false,
     useRenderMatrix: true,
+    useWidthCompression: false,
+    useConnector: true,
     beginEndBin: BeginEndBin,
     pixelsPerColumn: 7,
     pixelsPerRow: 7,
@@ -76,6 +78,12 @@ RootStore = types
     }
     function toggleUseRenderMatrix() {
       self.useRenderMatrix = !self.useRenderMatrix;
+    }
+    function toggleUseWidthCompression() {
+      self.useWidthCompression = !self.useWidthCompression;
+    }
+    function toggleUseConnector() {
+      self.useConnector = !self.useConnector;
     }
     function updateHeight(event) {
       self.pixelsPerRow = Math.max(1, Number(event.target.value));
@@ -140,6 +148,8 @@ RootStore = types
       updateCellTooltipContent,
       toggleUseVerticalCompression,
       toggleUseRenderMatrix,
+      toggleUseWidthCompression,
+      toggleUseConnector,
       updateHeight,
       updateWidth,
       tryJSONpath,

--- a/src/ViewportInputsStore.js
+++ b/src/ViewportInputsStore.js
@@ -1,9 +1,8 @@
 import { types } from "mobx-state-tree";
 import { urlExists } from "./URL";
 
-
 const BeginEndBin = types.optional(types.array(types.integer), [1, 40]);
-const ChunkURLs = types.optional(types.array(types.string), ['', '']);
+const ChunkURLs = types.optional(types.array(types.string), ["", ""]);
 
 const PathNucPos = types.model("PathNucPos", {
   path: types.string,
@@ -14,7 +13,6 @@ export let RootStore;
 RootStore = types
   .model({
     useVerticalCompression: false,
-    useRenderMatrix: true,
     useWidthCompression: false,
     useConnector: true,
     beginEndBin: BeginEndBin,
@@ -76,9 +74,6 @@ RootStore = types
     function toggleUseVerticalCompression() {
       self.useVerticalCompression = !self.useVerticalCompression;
     }
-    function toggleUseRenderMatrix() {
-      self.useRenderMatrix = !self.useRenderMatrix;
-    }
     function toggleUseWidthCompression() {
       self.useWidthCompression = !self.useWidthCompression;
     }
@@ -101,7 +96,7 @@ RootStore = types
         self.jsonName = event.target.value;
       }
     }
-    function switchChunkURLs(startFile, endFile){
+    function switchChunkURLs(startFile, endFile) {
       self.chunkURLs = [startFile, endFile];
     }
     function getChunkURLs() {
@@ -147,7 +142,6 @@ RootStore = types
       resetRenderStats,
       updateCellTooltipContent,
       toggleUseVerticalCompression,
-      toggleUseRenderMatrix,
       toggleUseWidthCompression,
       toggleUseConnector,
       updateHeight,

--- a/src/ViewportInputsStore.js
+++ b/src/ViewportInputsStore.js
@@ -14,6 +14,7 @@ RootStore = types
   .model({
     useVerticalCompression: false,
     useWidthCompression: false,
+    useConnector: true,
     beginEndBin: BeginEndBin,
     pixelsPerColumn: 7,
     pixelsPerRow: 7,
@@ -75,6 +76,9 @@ RootStore = types
     }
     function toggleUseWidthCompression() {
       self.useWidthCompression = !self.useWidthCompression;
+    }
+    function toggleUseConnector() {
+      self.useConnector = !self.useConnector;
     }
     function updateHeight(event) {
       self.pixelsPerRow = Math.max(1, Number(event.target.value));
@@ -139,6 +143,7 @@ RootStore = types
       updateCellTooltipContent,
       toggleUseVerticalCompression,
       toggleUseWidthCompression,
+      toggleUseConnector,
       updateHeight,
       updateWidth,
       tryJSONpath,

--- a/src/ViewportInputsStore.js
+++ b/src/ViewportInputsStore.js
@@ -14,7 +14,6 @@ RootStore = types
   .model({
     useVerticalCompression: false,
     useWidthCompression: false,
-    useConnector: true,
     beginEndBin: BeginEndBin,
     pixelsPerColumn: 7,
     pixelsPerRow: 7,
@@ -76,9 +75,6 @@ RootStore = types
     }
     function toggleUseWidthCompression() {
       self.useWidthCompression = !self.useWidthCompression;
-    }
-    function toggleUseConnector() {
-      self.useConnector = !self.useConnector;
     }
     function updateHeight(event) {
       self.pixelsPerRow = Math.max(1, Number(event.target.value));
@@ -143,7 +139,6 @@ RootStore = types
       updateCellTooltipContent,
       toggleUseVerticalCompression,
       toggleUseWidthCompression,
-      toggleUseConnector,
       updateHeight,
       updateWidth,
       tryJSONpath,

--- a/src/ViewportInputsStore.js
+++ b/src/ViewportInputsStore.js
@@ -14,6 +14,7 @@ RootStore = types
   .model({
     useVerticalCompression: false,
     useWidthCompression: false,
+    binScalingFactor: 3,
     useConnector: true,
     beginEndBin: BeginEndBin,
     pixelsPerColumn: 7,
@@ -55,6 +56,10 @@ RootStore = types
       if (Number.isFinite(newTopOffset) && Number.isSafeInteger(newTopOffset)) {
         self.topOffset = newTopOffset;
       }
+    }
+    function updateBinScalingFactor(event) {
+      let newFactor = event.target.value;
+      self.binScalingFactor = Math.max(1, Number(newFactor));
     }
     function updateHighlightedLink(linkRect) {
       self.highlightedLink = linkRect;
@@ -141,6 +146,7 @@ RootStore = types
       updateMaxHeight,
       resetRenderStats,
       updateCellTooltipContent,
+      updateBinScalingFactor,
       toggleUseVerticalCompression,
       toggleUseWidthCompression,
       toggleUseConnector,


### PR DESCRIPTION
Issue #35 
I fixed the Schematize. Further, I found CompressedViewSwitch won't work if default is `true`. I also fixed this.