### PR TITLE
[Bug] Components keep getting pushed to the left

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -41,7 +41,6 @@ const stringToColourSave = function (colorKey) {
 };
 
 class App extends Component {
-
   layerRef = React.createRef();
   layerRef2 = React.createRef(null);
   constructor(props) {
@@ -213,6 +212,7 @@ class App extends Component {
 
   updateHighlightedNode = (linkRect) => {
     this.setState({ highlightedLink: linkRect });
+    this.recalcXLayout();
     // this.props.store.updateHighlightedLink(linkRect); // TODO this does not work, ask Robert about it
   };
 


### PR DESCRIPTION
#### Describe the bug

After loading the screen, initially the components get rendered properly, but after some time(this implies a second render), components get crammed to the left. Also, after updating the row height, or updating the paths, the same is triggered. It looks like this:

![image](https://user-images.githubusercontent.com/11820306/78944339-5831e680-7ac6-11ea-8d3e-6c443c6ac75c.png)

Things get fixed after changing the column width. The reason for this is that when changing the column width, XLayout is recalculated. This patch(closes #54) works by doing the same everytime the link is highlighted. However, this seems to be expensive and can always be reworked.

#### To Reproduce

- Run `npm start`
- Wait anywhere between 0 - 30 seconds, change the row-height or set the position/ path then click jump

#### Expected behavior

- Components should be rendered properly

#### Screenshots

Fix looks like this:
![image](https://user-images.githubusercontent.com/11820306/78944541-cf677a80-7ac6-11ea-9af6-b09b1875b69c.png)

#### Environment setup (please complete the following information):
- Firefox 74

#### Additional context

- Read [this](https://stackoverflow.com/questions/41004631/trace-why-a-react-component-is-re-rendering) for an explanation of why there was a second render, and how to detect what triggered it.
- https://github.com/graph-genome/Schematize/issues/54#issuecomment-611766033